### PR TITLE
Improve service install, CLI arg config, use tomli & release 0.4.0

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -28,7 +28,21 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint.extensions.bad_builtin,
+             pylint.extensions.check_elif,
+             pylint.extensions.code_style,
+             pylint.extensions.comparetozero,
+             pylint.extensions.comparison_placement,
+             pylint.extensions.confusing_elif,
+             # pylint.extensions.consider_ternary_expression,  # Used a lot currently
+             # pylint.extensions.docparams,  # Enable when finished adding docstrings
+             pylint.extensions.docstyle,
+             pylint.extensions.empty_comment,
+             pylint.extensions.emptystring,
+             pylint.extensions.for_any_all,
+             pylint.extensions.overlapping_exceptions,
+             pylint.extensions.private_import,
+             pylint.extensions.redefined_variable_type,
 
 # Pickle collected data for later comparisons.
 persistent=yes
@@ -66,13 +80,17 @@ enable=all
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=missing-function-docstring,
-        missing-class-docstring,
-        too-few-public-methods,
-        import-error,
-        locally-disabled,
-        file-ignored,
-        suppressed-message,
+disable=locally-disabled,  # Allow checks to be locally disabled
+        file-ignored,  # Allow files to be ignore
+        suppressed-message,  # Allow messages to be suppressed
+        import-error,  # Ignore errors importing packages not in the current env
+        consider-using-assignment-expr,  # Don't require := for Python <3.8 compat
+        too-few-public-methods,  # Allow classes with just data
+        missing-function-docstring,  # Ignore missing function docstrings for now
+        missing-class-docstring,  # Ignore missing class docstrings for now
+        docstring-first-line-empty,  # Accept current style of module docstrings
+        consider-using-namedtuple-or-dataclass,  # Maybe in the future...
+        consider-using-tuple,  # Only for "style consistency"
 
 
 [REPORTS]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Brokkr Changelog
 
 
-## Version 0.4.0 Alpha 2 (2020-02-17)
+## Version 0.4.0 Alpha 2 (2021-02-17)
 
 Alpha release with the following changes:
 
@@ -135,7 +135,7 @@ Under the Hood:
 
 ## Version 0.2.5 (2020-01-24)
 
-Bugfix release with the following change:
+Bugfix release with the following changes:
 
 * Fix serious persistent error after disconnect/reconnecting charge controller
 * Improve serial port selection alg and ignore built-in ARM serial port

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,50 @@
 # Brokkr Changelog
 
 
+## Version 0.4.0 (2022-06-03)
+
+Stable release supporting Python 3.6-3.10.
+
+### Summary of changes since 0.3.x
+
+This is an overview of what's new in Brokkr 0.4.0 relative to 0.3.x stable.
+See the individual alpha release entries for full details.
+The remaining sections discuss the changes since the last alpha.
+
+* Add input and output queues to tie together multiple pipelines
+* Add support for TCP and arbitrary network packets as inputs
+* Add arbitrary binary decode on input and writing on output
+* Add external drive discovery, mounting and selection
+* Add ``install-scripts`` command to install symlinks to system scripts
+* Add ``netcat`` command to interactively send and receive network data
+
+### Core features
+
+* Add support for many new service installation options & per-mode services
+* Detect when not invoked from Brokkr's own CLI and ignore CLI args in config
+
+### Bug fixes
+
+* Fix FileOutputStep bug when processing unhashable DataValue types
+* Fix multiple bugs and issues with service installation
+
+### Infrastructure
+
+* Migrate from toml to tomli for better perf, maintenance & TOML 1.0.0 support
+* Modernize packaging infrastructure for PEP 517 w/pyproject.toml & setup.cfg
+* Officially document support for Python 3.10 (now supports 3.6-3.10)
+* Add detailed Contributing Guide and greatly expand Readme
+
+### Under the hood
+
+* Add hook to run custom callback on multiprocess worker start
+* Add extra debug logging during filepath rendering
+* Fix/suppress new Pylint messages & add a suite of extension checkers
+* Update Release Guide to use more modern and robust procedure
+* Further related refactoring
+
+
+
 ## Version 0.4.0 Alpha 2 (2021-02-17)
 
 Alpha release with the following changes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,100 +1,160 @@
-# Brokkr Contributing Guide
+# Contributing Guide
 
-Brokkr is part of Project Mjolnir, and is developed with standard Github flow. You should be familiar with the basics of using
+Brokkr is part of Project Mjolnir, and is developed with standard GitHub flow.
+
+If you're not comfortable with at least the basics of ``git`` and GitHub, we recommend reading beginner tutorials such as [GitHub's Git Guide](https://github.com/git-guides/), its [introduction to basic Git commands](https://guides.github.com/introduction/git-handbook/#basic-git) and its [guide to the fork workflow](https://guides.github.com/activities/forking/), or (if you prefer) their [video equivalents](https://www.youtube.com/githubguides).
+However, this contributing guide should fill you in on most of the basics you need to know.
+
+Let us know if you have any further questions, and we look forward to your contributions!
 
 
-## Reporting issues
+## Reporting Issues
 
-Discover a bug? Want a new feature? Open an issue! Make sure to describe in detail, with reproducible examples and references if possible, what you are looking to have fixed/added.
+Discover a bug?
+Want a new feature?
+[Open](https://github.com/project-mjolnir/brokkr/issues/new/choose) an [issue](https://github.com/project-mjolnir/brokkr/issues)!
+Make sure to describe the bug or feature in detail, with reproducible examples and references if possible, what you are looking to have fixed/added.
 While we can't promise we'll fix everything you might find, we'll certainly take it into consideration, and typically welcome pull requests to resolve accepted issues.
-Thanks!
 
 
 
 ## Setting Up a Development Environment
 
-### Forking and cloning the repo
+**Note**: You may need to substitute ``python3`` for ``python`` in the commands below on some Linux distros where ``python`` isn't mapped to ``python3`` (yet).
 
-First, navigate to the [Brokkr repo](https://github.com/project-mjolnir/brokkr) in your web browser and press the ``Fork`` button to make a personal copy of the repository on your own Github account.
+
+### Fork and clone the repo
+
+First, navigate to the [project repository](https://github.com/project-mjolnir/brokkr) in your web browser and press the ``Fork`` button to make a personal copy of the repository on your own GitHub account.
 Then, click the ``Clone or Download`` button on your repository, copy the link and run the following on the command line to clone the repo:
 
-```bash
-git clone <LINK-TO-YOUR-REPO>
+```shell
+git clone <LINK_TO_YOUR_REPO>
 ```
 
 Finally, set the upstream remote to the official Brokkr repo with:
 
-```bash
+```shell
 git remote add upstream https://github.com/project-mjolnir/brokkr.git
-```
-
-### Creating a conda environment or virtualenv
-
-If you use Anaconda, you can create a conda environment with the following commands:
-
-```bash
-conda create -n brokkr-dev python=3
-conda activate brokkr-dev
-```
-
-Otherwise, you can create a `venv`:
-
-```bash
-python3 -m venv brokkr-dev
-source brokkr-dev/bin/activate
+git fetch --all
 ```
 
 
-### Installing and running brokkr
+### Create and activate a fresh environment
 
-Finally, `cd` to the directory where your git clone is stored and install it:
+Particularly for development installs, we highly recommend you create and activate a virtual environment to avoid any conflicts with other packages on your system or causing any other issues.
+Of course, you're free to use any environment management tool of your choice (conda, virtualenvwrapper, pyenv, etc).
 
-```bash
+To do so with Conda (recommended), simply execute the following:
+
+```shell
+conda create -c conda-forge -n brokkr-env python=3.9
+```
+
+And activate it with
+
+```shell
+conda activate brokkr-env
+```
+
+With pip/venv, you can create a virtual environment with
+
+```shell
+python -m venv brokkr-env
+```
+
+And activate it with the following on Linux and macOS,
+
+```shell
+source brokkr-env/bin/activate
+```
+
+or on Windows (cmd),
+
+```cmd
+.\brokkr-env\Scripts\activate.bat
+```
+
+Regardless of the tool you use, make sure to remember to always activate your environment before using it.
+
+
+### Install Brokkr in editable mode
+
+Then, to install the Brokkr package and its dependencies in editable ("development") mode, where updates to the source files will be reflected in the installed package, and include any additional dependencies used for development, run
+
+```shell
 cd brokkr
-pip install -e .[all]
+python -m pip install -e .[all]
 ```
 
-You can then run Brokkr as normal, with the ``brokkr`` command.
-When you make changes in your local copy of the Brokkr git repository, they will be reflecting in your installed copy of Brokkr as soon as you re-run it.
+You can then import and run Brokkr as normal, with the ``brokkr`` command (or ``python -m brokkr``).
+When you make changes in your local copy of the git repository, they will be reflected in your installed copy as soon as you re-run Python.
 
 On Windows and Mac, use of Anaconda/Miniconda is recommended, though not required.
 While these platforms are supported for development, some install and system-management functionality specific to running Brokkr in production may be unavailable.
 
 
 
-## Brokkr Branches
+## Deciding Which Branch to Target
 
-When you start to work on a new pull request (PR), you need to be sure that your work is done on top of the correct Brokkr branch, and that you base your PR on Github against it.
+When you start to work on a new pull request (PR), you need to be sure that your work is done on top of the correct branch, and that you base your PR on GitHub against it.
 
-To guide you, issues on Github are marked with a milestone that indicates the correct branch to use. If not, follow these guidelines:
+To guide you, issues on GitHub are typically marked with a milestone that indicates the correct branch to use.
+If not, follow these guidelines:
 
-* Use the latest release branch (e.g. `0.3.x` for bugfixes only (*e.g.* milestones `v0.3.1` or `v0.3.2`)
-* Use `master` to introduce new features or break compatibility with previous Brokkr versions (*e.g.* milestones `v0.4alpha2` or `v0.4beta1`).
+* Use the latest release branch for bugfixes only (e.g. ``0.3.x``, with milestones ``v0.3.1`` or ``v0.3.x``)
+* Use ``master`` to introduce new features or break compatibility with previous Brokkr versions (e.g. milestones ``v0.4alpha2`` or ``v0.4.0``).
 
-You should also submit bugfixes to the release branch or `master` for errors that are only present in those respective branches.
+Of course, for issues that are only present in those respective branches, target your PRs against that specific branch.
 
 
 
-## Submitting a PR
+## Making Your Changes
 
-To start working on a new PR, you need to execute these commands, filling in the branch names where appropriate (``<BASE-BRANCH>`` is the branch you're basing your work against, e.g. ``master``, while ``<FEATURE-BRANCH>`` is the branch you'll be creating to store your changes, e.g. ``fix-startup-bug`` or ``add-uart-support``:
-
-```bash
-$ git checkout <BASE-BRANCH>
-$ git pull upstream <BASE-BRANCH>
-$ git checkout -b <FEATURE-BRANCH>
-```
-
-Once you've made and tested your changes, commit them with a descriptive message of 74 characters or less written in the imperative tense, with a capitalized first letter and no period at the end. For example:
+To start working on a new PR, you need to execute these commands, filling in the branch names where appropriate (``<BASE-BRANCH>`` is the branch you're basing your work against, e.g. ``master``, while ``<FEATURE-BRANCH>`` is the branch you'll be creating to store your changes, e.g. ``fix-startup-bug`` or ``add-widget-support``:
 
 ```bash
-git commit -am "Fix bug reading uart device on Windows"
+git checkout <BASE-BRANCH>
+git pull upstream <BASE-BRANCH>
+git checkout -b <FEATURE-BRANCH>
 ```
 
-Finally, push them to your fork, and create a pull request to the project-mjolnir/brokkr repository on Github:
+Once you've made and tested your changes, commit them with a descriptive, unique message of 74 characters or less written in the imperative tense, with a capitalized first letter and no period at the end.
+Try to make your commit message understandable on its own, giving the reader a high-level idea of what your changes accomplished without having to dig into the diffs.
+For example:
+
+```bash
+git commit -am "Fix bug reading env variable when importing package on Windows"
+```
+
+If your changes are complex (more than a few dozen lines) and can be broken into discrete steps/parts, its often a good idea to make multiple commits as you work.
+On the other hand, if your changes are fairly small (less than a dozen lines), its usually better to make them as a single commit, and then use the ``git -a --amend`` (followed by ``git push -f``, if you've already pushed your work) if you spot a bug or a reviewer requests a change.
+
+These aren't hard and fast rules, so just use your best judgment, and if there does happen to be a significant issue we'll be happy to help.
+
+
+## Testing your Work
+
+While a formal test suite for the project is still in work, you should still test them locally, and on a deployed installation if possible.
+For the former, make sure that ``brokkr status``/``brokkr monitor`` displays correctly, ``brokkr --mode test start`` runs without unexpected errors, and that any commands relevant to your work function as intended.
+If an error occurs, adding one or more ``-v`` verbose flags, or using the ``--log-level-file`` and ``--log-level-console`` options are very helpful for debugging.
+
+
+
+## Pushing your Changes and Submitting a Pull Request
+
+Now that your changes are ready to go, you'll need to push them to the appropriate remote.
+All contributors, including core developers, should push to their personal fork and submit a PR from there, to avoid cluttering the upstream repo with feature branches.
+To do so, run:
 
 ```bash
 git push -u origin <FEATURE-BRANCH>
 ```
 
-That's it!
+Where ``<FEATURE-BRANCH>`` is the name of your feature branch, e.g. ``fix-startup-bug``.
+
+Finally, create a pull request to the [project-mjolnir/brokkr repository](https://github.com/project-mjolnir/brokkr/) on GitHub.
+Make sure to set the target branch to the one you based your PR off of (``master`` or ``X.x``).
+We'll then review your changes, and after they're ready to go, your work will become an official part of Brokkr.
+
+Thanks for taking the time to read and follow this guide, and we look forward to your contributions!

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019- C.A.M. Gerlach/UAH HAMMA Group and contributors
+Copyright (c) 2019-2022 C.A.M. Gerlach, the UAH HAMMA Group and the Project Mjolnir Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include CHANGELOG.md
+include CONTRIBUTING.md
 include LICENSE.txt
 include README.md
 include ROADMAP.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include CHANGELOG.md
 include CONTRIBUTING.md
 include LICENSE.txt
 include README.md
+include RELEASE.md
 include ROADMAP.md

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The goal of Project Mjolnir is to make it easy for PIs or students without a cod
 The long-term vision is to create an ecosystem of open-source presets, plugins, examples and more for a wide variety of low-cost scientific IoT sensors.
 
 
+
 ## Key Features
 
 * Support for SPI, I2C, GPIO, Analog, SMBus, UART, Modbus, TCP, UDP, and more as inputs, and print/pretty print, file and system logging, CSV, and TCP packets as output built into the core
@@ -20,41 +21,42 @@ The long-term vision is to create an ecosystem of open-source presets, plugins, 
 * System-independent and fully multi-system capable; all metadata, config, plugins and presets stored within VCS-trackable self-contained package for easy management
 
 
-## Requirements
-
-Built and tested under Python 3.7 (but should be compatible with Python >=3.6; lack thereof should be considered a bug), and should be forward-compatible with Python 3.8 (albeit as yet not fully tested).
-Compatible and tested with recent (>= 2019) versions of the packages listed in the ``requirements.txt`` file.
-Works best on Linux, but is tested to be fully functional (aside from service features) on Windows (and _should_ work equally macOS) under the Anaconda distribution.
-
 
 ## License
 
-Copyright (c) 2019-2021 C.A.M. Gerlach, the UAH HAMMA Group and the Project Mjolnir Contributors
+Copyright (c) 2019-2022 C.A.M. Gerlach, the UAH HAMMA Group and the Project Mjolnir Contributors
 
-This project is released under the terms of the MIT (Expat) License; see LICENSE.txt for more details.
+This project is distributed under the terms of the MIT (Expat) License; see the [LICENSE.txt](./LICENSE.txt) for more details.
+
 
 
 ## Installation and Setup
 
+Brokkr is built and tested under Python 3.6-3.10, with a relatively minimal set of lightweight, pure-Python core dependencies.
+It works best on Linux, but is tested to be fully functional (aside from service features) on Windows (and _should_ work equally on macOS) using the Anaconda distribution.
+
 
 ### Standard install
 
-On Linux, Brokkr can be installed like any other Python package via ``pip`` into a virtual environment like so (with the venv created inside `ENV_NAME` in the current working directory), with the extra packages needed to support specific sensor types (e.g. ``modbus``, ``serial``, ``adafruit``, ``all`` etc) installed as desired:
+On Linux (or other platforms, for experienced users), Brokkr can be installed like any other Python package, via ``pip`` into a ``venv`` virtual environment.
 
-```bash
+For example, with the venv created inside ``ENV_DIR`` in the current working directory, and installing the ``EXTRA`` packages needed to support specific sensor types (e.g. ``modbus``, ``serial``, ``adafruit``, etc, or ``all`` for all of them) as desired:
+
+```shell
 python3 -m venv ENV_DIR
 source ENV_DIR/bin/activate
 pip install brokkr[EXTRA1,EXTRA2...]
 ```
 
-For information on installing a development version, see the contributing guide:
+On Windows and Mac, use of Anaconda/Miniconda is recommended, substituting conda environments for venvs.
+While these platforms are supported for development, some functionality specific to running Brokkr in production may be unavailable.
 
-On Windows and Mac, use of Anaconda/Miniconda is recommended, substituting conda environments for venvs. While these platforms are supported for development, some functionality specific to running Brokkr in production may be unavailable.
+For information on installing a development version, see the [Contributing Guide](./CONTRIBUTING.md).
 
 Then, you need to take a few more steps to get your environment set up: clone the system config package(s) you want to use with Brokkr (replace the example ``mjolnir-config-template`` path with yours), register them, and set up your config and unit information.
 ``SYSTEM_SHORTNAME`` is whatever name you want to register the system with in the system file, and ``UNIT_NUMBER`` is the integer number (arbitrary, but should be unique) you want to designate the device you're installing on.
 
-```
+```shell
 git clone https://github.com/project-mjolnir/mjolnir-config-template.git
 brokkr configure-system SYSTEM_SHORTNAME /path/to/system/mjolnir-config-template
 brokkr configure-init
@@ -64,31 +66,33 @@ brokkr configure-unit UNIT_NUMBER
 Finally, you can run the post-installation setup steps as needed for your system.
 First, you'll want to install any system-specific dependencies,
 
-```bash
+```shell
 brokkr install-dependencies
 ```
 
-Then, to just install the systemd service unit to run Brokkr on startup:
+Then, to just install the Systemd service unit to run Brokkr on startup, run:
 
-```bash
-sudo /path/to/virtual/environment/ENV_DIR/bin/python -m brokkr install-service``
+```shell
+sudo /PATH/TO/ENV_DIR/bin/python -m brokkr install-service``
 brokkr install-dependencies
 ```
 
-or, for a full install of all post-setup tasks, including the config files, scripts, system-specific dependencies, firewall access, and (on Linux) serial port access, Brokkr systemd service, and SSH/AutoSSH service and configuration:
+You can set a specific account, install path and startup arguments if desired; see ``brokkr install-service --help`` for more usage and option information.
 
-```
-sudo /path/to/virtual/environment/ENV_DIR/bin/python -m brokkr install-all
+For a full install of all post-setup tasks, including the config files, scripts, system-specific dependencies, firewall access, and (on Linux) serial port access, Brokkr systemd service, and SSH/AutoSSH service and configuration, you can instead run:
+
+```shell
+sudo /PATH/TO/ENV_DIR/bin/python -m brokkr install-all
 brokkr install-dependencies
 ```
 
-Finally, you can check that Brokkr is working with ``brokkr --version``, ``brokkr status`` and the other commands detailed in ``brokkr --help``.
+Finally, you can check that Brokkr is installed and set up correctly with ``brokkr --version``, ``brokkr status`` and the other commands detailed in ``brokkr --help``.
 Simply reboot to automatically complete setup and start the ``brokkr`` service, or on all platforms you can manually execute it on the command line immediately with ``brokkr start``.
 
 
-### Automated clean install
+### Automated clean install (under development)
 
-However, for setup on typical IoT devices (i.e. single-board computers like the Raspberry Pi) running a clean copy of a modern Linux-based operating system, Brokkr features a comprehensive setup routine that can bootstrap all key aspects of a factory-fresh system to be ready for deployment in the field.
+For setup on typical IoT devices (i.e. single-board computers like the Raspberry Pi) running a clean copy of a modern Linux-based operating system, Brokkr features a comprehensive setup routine that can bootstrap all key aspects of a factory-fresh system to be ready for deployment in the field.
 Simply declare the configuration files you want copied, packages and services you want installed/enabled/disabled/removed, firewall ports you want open closed, and other custom actions (move files, sed scripts, commands run, etc) for each phase of the install as part of the system config package, and on your command, brokkr will do the rest.
 
 A typical semi-automated install flow might look like the following
@@ -127,20 +131,24 @@ On site, you'll want to take a couple additional actions to pair a specific devi
 
 ## Usage
 
-
 ### Overview
 
-Run the `brokkr status` command to get a snapshot of the monitoring data, and the `brokkr monitor` command to get a pretty-printed display of all the main monitoring variables, updated in real time (1s) as you watch.
+See ``brokkr --help`` and ``brokkr <SUBCOMMAND> --help`` for detailed documentation of Brokkr's CLI, invocation, options and subcommands.
+The following is a brief, high-level summary.
 
-The ``brokkr install-*`` commands perform installation functions and the ``brokkr configure-*`` scripts help set up a new or updated ``brokkr`` install.
-Use ``brokkr --help`` to get help, ``brokkr --version`` to get the current version.
-On Linux, the ``brokkr`` systemd service can be interacted with via the standard systemd commands, e.g. ``sudo systemd {start, stop, enable, disable} brokkr-hamma``, ``systemd status brokkr-hamma``, ``journalctl -u brokkr-hamma``, etc, and the same for ``autossh-brokkr`` which controls remote SSH connectivity.
+For a quick check of Brokkr, its version and that of the current system (if configured), use ``brokkr --version``.
+Run the ``brokkr status`` command to get a snapshot of the monitoring data, and the ``brokkr monitor`` command to get a pretty-printed display of all the main monitoring variables, updated in real time (every 1 s by default) as you watch.
+``brokkr start`` is the main entrypoint for Brokkr's core functionality, loading and executing the configured data acquisition, processing and output pipelines, and in normal usage is run though the Brokkr service.
+
+The ``brokkr install-*`` commands perform installation functions and the ``brokkr configure-*`` functionality helps set up a new or updated ``brokkr`` install.
+On Linux, the ``brokkr-SYSTEMNAME`` systemd service can be interacted with via the standard systemd commands, e.g. ``sudo systemd {start, stop, enable, disable} brokkr-SYSTEMNAME``, ``systemd status brokkr-SYSTEMNAME``, ``journalctl -u brokkr-SYSTEMNAME``, etc, and the same for ``autossh-brokkr`` which controls remote SSH connectivity.
 
 
 ### Interactive Use (Foreground)
-First activate the appropriate Python virtual environment (``source ENV_DIR/bin/activate``).
 
-Then:
+First, activate the appropriate Python virtual environment (e.g. ``source ENV_DIR/bin/activate``).
+
+Then, you have a few options:
 
 * Main foreground start command, for testing: ``brokkr start``
 * Oneshot status output: ``brokkr status``
@@ -149,15 +157,15 @@ Then:
 
 ### Running Brokkr as a Service (Background)
 
-* Generate, install and enable service automatically
+* Generate, install and enable service automatically:
     * ``sudo /home/pi/path/to/ENV_DIR/bin/python -m brokkr install-service``
-* Start/stop
+* Start/stop:
     * ``sudo systemctl start brokkr-SYSTEMNAME``
-    * ``sudo systemctl start brokkr-SYSTEMNAME``
-* Enable/disable running on startup
+    * ``sudo systemctl stop brokkr-SYSTEMNAME``
+* Enable/disable running on startup:
     * ``sudo systemctl enable brokkr-SYSTEMNAME``
     * ``sudo systemctl disable brokkr-SYSTEMNAME``
-* Basic status check and latest log output
+* Basic status check and latest log output:
     * ``systemctl status brokkr-SYSTEMNAME``
 * Full log output (also logged to text file ``~/brokkr/hamma/brokkr_hamma_NNN.log``)
     * ``journalctl -xe -u brokkr-SYSTEMNAME``
@@ -167,9 +175,9 @@ Then:
 ## Configuration
 
 A major design goal of Brokkr and the Mjolnir system is extensive, flexible and straightforward reconfiguration for different sensor networks and changing needs.
-All the system configuration is normally handled through the Mjolnir-HAMMA system config package in the standard Mjolnir config schema developed for this system (located at ~/dev/mjolnir-hamma), aside from a few high-level elements specific to each unit which all have interactive configuration commands as below.
+For example, with the UAH HAMMA2 system, all the system configuration is normally handled through the [Mjolnir-HAMMA system config package](https://github.com/hamma-dev/mjolnir-hamma/) in the standard Mjolnir config schema developed for this system, aside from a few high-level elements specific to each unit which all have interactive configuration commands as below.
 
-However, if local customization is needed beyond the high-level options specified here, instead of modifying the version-control-tracked system config package directly, the config system built for this is fully hierarchical and all settings can be fully overridden via the corresponding local config in ~/.config/brokkr/hamma
+However, if local customization is needed beyond the high-level options specified here, instead of modifying the version-control-tracked system config package directly, the config system built for this is fully hierarchical and all settings can be fully overridden via the corresponding local config in ``~/.config/brokkr/SYSTEM_NAME``.
 Brokkr fully supports configuration, logging, operation and output of any number of Mjolnir systems simultaneously, all on the same Pi.
 
 Configuration files are located under the XDG-standard ``~/.config/brokkr`` directory in the ini-like [TOML](https://github.com/toml-lang/toml) format; they can be generated by running ``brokkr configure-init`` (which will not overwrite them if they already exist), and reset to defaults with ``brokkr configure-reset``.
@@ -181,26 +189,26 @@ Configuration files are located under the XDG-standard ``~/.config/brokkr`` dire
 
 Register a Mjolnir system:
 
-```bash
+```shell
 brokkr configure-system <SYSTEM-NAME> </PATH/TO/SYSTEM/CONFIG/DIR>
 ```
 
 (e.g. ``brokkr configure-system hamma /home/pi/dev/mjolnir-hamma``)
 
-You can also use this command to remove, update, verify and set default systems with the appropriate arguments, see brokkr configure-system --help``
+You can also use this command to remove, update, verify and set default systems with the appropriate arguments; see ``brokkr configure-system --help``
 
 
 #### Generate local config files
 
 Generate empty local per-system (i.e. override) config files if not already present:
 
-```
+```shell
 brokkr configure-init
 ```
 
 #### Set per-unit configuration
 
-```
+```shell
 brokkr configure-unit <UNIT_NUMBER> --network-interface <INTERFACE>
 ```
 
@@ -209,8 +217,8 @@ brokkr configure-unit <UNIT_NUMBER> --network-interface <INTERFACE>
 
 #### Reset configuration
 
-Reset unit and local override configuration (optionally minus system registry):
+Reset unit and local override configuration (optionally minus the system registry):
 
-```
+```shell
 brokkr configure-reset
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,39 +1,346 @@
-# Release instructions for Brokkr
+# Release Procedure
 
-## Perform pre-release tasks
+You can copy the raw source of this document to an issue or pull request for the release to use as an interactive checklist, if desired.
 
-1. Ensure ``MANIFEST.in``, ``setup.cfg`` and README/docs are up to date and commit any changes
-2. Test the development version: ``brokkr monitor`` and ``brokkr start``
-3. Close Github milestone (if open)
-4. Check ``git status`` then ensure repo is up to date: ``hub sync`` (``git fetch upstream && git pull upstream master && git push origin master``)
-5. Update version in ``brokkr/__init__.py`` to release version and add ``CHANGELOG.md`` entry
+**Note**: We use `pip` instead of `conda` here even on Conda installs, to ensure we always get the latest upstream versions of the build dependencies.
 
 
-## Build and test
+## Prepare
 
-1. Activate the appropriate venv/Conda env: ``source env/bin/activate`` or ``conda activate ENV_NAME``
-2. Update packaging packages: ``conda install wheel setuptools pip packaging` (if conda env) or ``pip install --upgrade setuptools wheel packaging`` (otherwise); then install build ``pip install --upgrade build pep517``
-4. Build source and wheel distributions: ``python -m build``
-5. In a clean env, install the build: ``pip install dist/brokkr-X.Y.Z.TAG-py3-none-any.whl``
-6. Test the installed version: ``brokkr monitor`` and ``brokkr start``
+* [ ] Close [GitHub milestone](https://github.com/project-mjolnir/brokkr/milestones) and ensure all issues are resolved/moved
+
+* [ ] In a bash-like shell locally and on the Pi/server, set up the variables needed (otherwise, replace them manually)
+
+  ```bash
+  # Full version number to release, e.g. '1.2.3b4'
+  VERSION='VERSION_NUMBER'
+  # Git branch to make the release from, e.g. 'main', 'master' or '1.x'
+  MAIN_BRANCH='BRANCH_NAME'
+  # Prepare-release branch name
+  PREPARE_RELEASE_BRANCH=prepare-release-$VERSION
+  # Release branch name, if a new major/minor release, e.g. '1.x' or '0.4.x'
+  RELEASE_BRANCH=$MAIN_BRANCH
+  # Set mode to 'client' (if on a Pi) or 'server' (if on the central VPS)
+  MODE='MODE_NAME'
+  ```
+
+  or, all in one line,
+
+  ```bash
+  VERSION='VERSION_NUMBER'; MAIN_BRANCH='BRANCH_NAME'; PREPARE_RELEASE_BRANCH=prepare-release-$VERSION; RELEASE_BRANCH=$MAIN_BRANCH; MODE='MODE_NAME'
+  ```
+
+* [ ] Update local repo
+
+  ```shell
+  git reset --hard && git switch $MAIN_BRANCH && git pull upstream $MAIN_BRANCH
+  ```
+
+* [ ] Clean local repo
+
+  ```shell
+  git clean -xdi
+  ```
+
+* [ ] Perform a quick local smoke-test of the final development version
+
+  ```shell
+  python -b -X dev -m pip install -e .
+  pylint src/brokkr
+  python -I -bb -X dev -W error -m brokkr --version
+  python -I -bb -X dev -W error -m brokkr monitor
+  python -I -bb -X dev -W error -m brokkr --mode test start
+  tail -n 10 "$(ls -t ~/brokkr/test/telemetry/telemetry* | head -n 1)"
+  ```
 
 
-## Upload to PyPI (production release)
+## Commit
 
-1. Install/update Twine: ``conda install twine`` or ``pip install --upgrade twine``
-2. Perform basic checks: ``twine check --strict dist/*``
-3. Upload to TestPyPI first ``twine upload --repository testpypi dist/*``
-4. In your development venv/conda env, download/install: ``pip install --index-url https://test.pypi.org/simple/ --no-deps brokkr``
-5. Test the installed version: ``brokkr monitor`` and ``brokkr start``
-6. Upload to live PyPI: ``twine upload dist/*``
+* [ ] Create a new branch for the release
+
+  ```shell
+  git switch -c $PREPARE_RELEASE_BRANCH
+  ```
+
+* [ ] Ensure docs and metadata are up to date and commit any changes
+
+  * [ ] [Release Guide](./RELEASE.md)
+  * [ ] [License](./LICENSE.txt)
+  * [ ] [Readme](./README.md)
+  * [ ] [Contributing Guide](./CONTRIBUTING.md)
+  * [ ] [MANIFEST.in](./MANIFEST.in)
+  * [ ] [setup.cfg](./setup.cfg) (Python/dep version reqs, classifiers, other metadata)
+  * [ ] [Roadmap](./ROADMAP.md)
+
+* [ ] Update [`CHANGELOG.md`](./CHANGELOG.md) with the latest changes
+
+* [ ] Update `__version__` in [`__init__.py`](./src/brokkr/__init__.py) (set release version, remove `.dev0`)
+
+  ```shell
+  nano src/brokkr/__init__.py
+  ```
+
+* [ ] Create release commit
+
+  ```shell
+  git commit -m "Release Brokkr version $VERSION"
+  ```
+
+* [ ] Push the prepare-release branch to your fork
+
+  ```shell
+  git push -u origin $PREPARE_RELEASE_BRANCH
+  ```
+
+* [ ] Open a [pull request](https://github.com/project-mjolnir/brokkr/pulls) for the branch
 
 
-## Execute release
+## Test
 
-1. Re-install dev build: ``pip install -e .``
-2. Commit release: ``git commit -am "Release Brokkr version X.Y.Z"``
-3. Tag release: ``git tag -a vX.Y.Z -m "Brokkr version X.Y.Z"``
-4. If new major or minor version (X or Y in X.Y.Z), create release branch to maintain deployed version: ``git checkout -b X.Y.x && git push -u origin X.Y.x && git push upstream X.Y.z && git checkout master``
-5. If release from ``master``, increment ``__version__`` in ``__init__.py`` to next expected release and add ``dev0`` (or ``dev<N+1>``, if a pre-release)
-6. Commit change back to dev mode on ``master``: ``git commit -am "Begin development of version X.Y.x"``
-7. Push changes upstream and to user repo: ``git push upstream master --follow-tags && git push origin master``
+* [ ] On the Pi/server, pull the prepare-release branch
+
+  ```shell
+  git reset --hard && git fetch --all && git switch $PREPARE_RELEASE_BRANCH
+  ```
+
+* [ ] Clean repository of old artifacts
+
+  ```shell
+  git clean -xdi
+  ```
+
+* [ ] Create and activate a fresh virtual environment for testing
+
+  ```shell
+  python -m venv test-env && source test-env/bin/activate
+  ```
+
+* [ ] Install/update the packaging stack
+
+  ```build
+  python -m pip install --upgrade pip
+  pip install --upgrade build setuptools wheel
+  ```
+
+* [ ] Build the distribution packages
+
+  ```build
+  python -bb -X dev -W error -m build
+  ```
+
+* [ ] Install from built wheel
+
+  ```shell
+  python -b -X dev -m pip install dist/brokkr-$VERSION-py3-none-any.whl[all]
+  ```
+
+* [ ] Check environment
+
+  ```shell
+  pip check; python -I -bb -X dev -W error -m brokkr --version
+  ```
+
+* [ ] Test package
+
+  ```
+  python -I -bb -X dev -W error -m brokkr status
+  python -I -bb -X dev -W error -m brokkr monitor
+  python -I -bb -X dev -W error -m brokkr --mode test start
+  ls -lh ~/brokkr/test/telemetry
+  head -n 10 "$(ls -t ~/brokkr/test/telemetry/telemetry* | head -n 1)"
+  tail -n 10 "$(ls -t ~/brokkr/test/telemetry/telemetry* | head -n 1)"
+  ```
+
+
+## Stage
+
+* [ ] On the Pi/server(s), activate the production virtual environment
+
+* [ ] Disable and stop Brokkr service
+
+  ```shell
+  sudo systemctl disable brokkr-hamma-default && sudo systemctl stop brokkr-hamma-default
+  ```
+
+* [ ] Reinstall the package from the built wheel
+
+  ```shell
+  python -b -X dev -m pip install dist/brokkr-$VERSION-py3-none-any.whl
+  ```
+
+* [ ] Reinstall service
+
+  ```shell
+  sudo /$PATH_TO_VENV/bin/python -I -bb -X dev -W error -m brokkr install-service -vvv --account $ACCOUNT
+  ```
+
+* [ ] Restart services
+
+  ```shell
+  sudo systemctl restart brokkr-hamma-default sindri-hamma-$MODE
+  ```
+
+* [ ] Verify still running, no errors and functioning correctly after 60 seconds
+
+  ```shell
+  systemctl status brokkr-hamma-default sindri-hamma-$MODE
+  ```
+
+
+## Build
+
+* [ ] Activate the appropriate venv/conda environment
+
+* [ ] Clean local repo
+
+  ```shell
+  git clean -xdi
+  ```
+
+* [ ] Update the packaging stack
+
+  ```shell
+  python -m pip install --upgrade pip
+  pip install --upgrade --upgrade-strategy eager build setuptools twine wheel
+  ```
+
+* [ ] Build source distribution and wheel
+
+  ```shell
+  python -bb -X dev -W error -m build
+  ```
+
+
+## Check
+
+* [ ] Check Pylint
+
+  ```shell
+  pylint src/brokkr
+  ```
+
+* [ ] Check distribution archives
+
+  ```shell
+  twine check --strict dist/*
+  ```
+
+* [ ] Check installation
+
+  ```shell
+  python -b -X dev -m pip install dist/brokkr-$VERSION-py3-none-any.whl
+  ```
+
+* [ ] Check environment
+
+  ```shell
+  pip check; python -I -bb -X dev -W error -m brokkr --version
+  ```
+
+* [ ] Check functionality
+
+  ```shell
+  python -I -bb -X dev -W error -m brokkr monitor
+  python -I -bb -X dev -W error -m brokkr --mode test start
+  tail -n 10 "$(ls -t ~/brokkr/test/telemetry/telemetry* | head -n 1)"
+  ```
+
+
+## Release
+
+* [ ] Upload distribution packages to PyPI
+
+  ```shell
+  twine upload dist/*
+  ```
+
+* [ ] Create release tag
+
+  ```shell
+  git tag -a v$VERSION -m "Brokkr version $VERSION"
+  ```
+
+* [ ] Merge the prepare-release branch to `$MAIN_BRANCH`, or the pull request
+
+  ```shell
+  git switch $MAIN_BRANCH && git merge $PREPARE_RELEASE_BRANCH
+  ```
+
+* [ ] If new major or minor version, create release branch and push
+
+  ```shell
+  git switch -c $RELEASE_BRANCH && git push -u origin $RELEASE_BRANCH && git push upstream $RELEASE_BRANCH && git switch $MAIN_BRANCH
+  ```
+
+
+## Finalize
+
+* [ ] Update `__version__` in [`__init__.py`](./src/brokkr/__init__.py) (increment to next, add `.dev0`)
+
+  ```shell
+  nano src/brokkr/__init__.py
+  ```
+
+* [ ] Create a `back to work` commit with the next anticipated version on the branch
+
+  ```shell
+  git commit -m "Begin development of version $VERSION"
+  ```
+
+* [ ] Reinstall the development version locally in editable mode
+
+  ```shell
+  python -b -X dev -m pip install -e .
+  ```
+
+* [ ] Push new release commits and tags to `$MAIN_BRANCH`
+
+  ```shell
+  git push upstream $MAIN_BRANCH --follow-tags
+  ```
+
+* [ ] Create a [GitHub release](https://github.com/project-mjolnir/brokkr/releases) from the tag with the changelog contents
+
+* [ ] Open a [GitHub milestone](https://github.com/project-mjolnir/brokkr/milestones) as needed for the next release
+
+
+## Deploy
+
+* [ ] On the Pi/server, install the released version from PyPI
+
+  ```shell
+  pip install brokkr
+  ```
+
+  Or, pull the release branch, checkout the tag and editable-install
+
+  ```shell
+  git fetch --all && git switch $RELEASE_BRANCH && git checkout v$VERSION && pip install -e .
+  ```
+
+* [ ] Restart the service and verify working
+
+  ```shell
+  sudo systemctl restart brokkr-hamma-default && sleep 10 && systemctl status brokkr-hamma-default
+  ```
+
+
+## Cleanup
+
+* [ ] On the Pi/server, remove the clean test virtual environment
+
+  ```shell
+  rm -rfd test-env
+  ```
+
+* [ ] Delete the prepare-release branch locally and on the Pi/server
+
+  ```shell
+  git branch -d $PREPARE_RELEASE_BRANCH
+  ```
+
+* [ ] Delete the prepare-release branch on the remote
+
+  ```shell
+  git push -d origin $PREPARE_RELEASE_BRANCH
+  ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,18 +1,10 @@
 # Brokkr Roadmap
 
 
-## Version 0.4.0 (NET March 2021)
+## Version 0.5.0
 
-* Read in and write out high-bandwidth TCP datastreams
-* Add handling for mounting, management and cleanup of external USB devices
-* Decode, process and write asynchronous header data from datastreams
-* Add additional sensor device steps and presets (SPI, GPIO, GPS, UART, etc)
 * Add comprehensive system monitoring with psutil, network status and vcgencmd
-
-
-
-## Version 0.5.0 (NET Summer 2021)
-
+* Add additional sensor device steps and presets (SPI, GPIO, GPS, UART, etc)
 * Implement rsync uplink of monitoring data, logging, and AGS packet headers
 * Add sophisticated, configurable, multi-phase bootstrap/install/setup system
 * Implement intelligent watchdog to reset network link or reboot device on errors
@@ -20,7 +12,7 @@
 
 
 
-## Version 1.0.0 (NET Fall 2021)
+## Version 1.0.0
 
 * Factor modular components (confighandler, loghandler, mphandler, etc) into packages
 * Add additional processing steps for statistics and diagnostics on ingested data
@@ -30,9 +22,8 @@
 
 
 
-## Version 1.1.0 (NET Late 2021?)
+## Version 1.1.0
 
 * Add sync config command?
 * Add high-level remote configuration and management functionality?
 * Validate config with JSONschema?
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-    "wheel",
-]
+requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,8 @@ install_requires =
     packaging
     serviceinstaller >= 0.1.3; sys_platform == 'linux'
     simpleeval
-    toml
+    tomli>=1.1
+    tomli_w>=0.4
 
 [options.extras_require]
 all =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,51 +1,58 @@
 [metadata]
 name = brokkr
 version = attr: brokkr.__version__
-author = C.A.M. Gerlach/UAH HAMMA group
-author_email = CAM.Gerlach@Gerlach.CAM
 description = A client for data ingest/logging/uplink, remote management and autonomous and central control of scientific IoT sensors as part of the Mjolnir system.
 long_description = file: README.md
 long_description_content_type = text/markdown
+url = https://github.com/project-mjolnir/brokkr
+author = C.A.M. Gerlach/UAH HAMMA group
+author_email = CAM.Gerlach@Gerlach.CAM
 license = MIT
 license_files =
     LICENSE.txt
-keywords = iot lightning sensor remote control research m2m raspberry pi rpi
-url = https://github.com/project-mjolnir/brokkr
-project_urls =
-    Github = https://github.com/project-mjolnir/brokkr
-    Bug Tracker = https://github.com/project-mjolnir/brokkr/issues
-    Demo = https://hamma.dev/
 classifiers =
     Development Status :: 4 - Beta
     Environment :: Console
     Environment :: No Input/Output (Daemon)
     Intended Audience :: Science/Research
-    License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)
+    License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3 :: Only
     Topic :: Scientific/Engineering :: Atmospheric Science
     Topic :: Scientific/Engineering :: Physics
     Topic :: System :: Monitoring
     Topic :: System :: Networking :: Monitoring :: Hardware Watchdog
+keywords = iot lightning sensor remote control research m2m raspberry pi rpi
+project_urls =
+    Github = https://github.com/project-mjolnir/brokkr
+    Bug Tracker = https://github.com/project-mjolnir/brokkr/issues
+    Demo = https://hamma.dev/
 
 [options]
 packages = find:
+install_requires =
+    packaging
+    serviceinstaller>=0.2.0;sys_platform == 'linux'
+    simpleeval
+    tomli>=1.1
+    tomli-w>=0.4
+python_requires = >=3.6
+include_package_data = True
 package_dir =
     = src
 zip_safe = False
-include_pacakge_data = True
-python_requires = >=3.6
-install_requires =
-    packaging
-    serviceinstaller >= 0.2.0; sys_platform == 'linux'
-    simpleeval
-    tomli>=1.1
-    tomli_w>=0.4
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+console_scripts =
+    brokkr = brokkr.__main__:main
 
 [options.extras_require]
 all =
@@ -56,25 +63,14 @@ all =
     pyserial
     RPi.GPIO
     smbus2
-
 adafruit =
     Adafruit-Blinka
     adafruit-circuitpython-busdevice
-
 gpio =
     gpiozero
     RPi.GPIO
-
 modbus =
     pymodbus
     pyserial
-
 smbus =
     smbus2
-
-[options.entry_points]
-console_scripts =
-    brokkr = brokkr.__main__:main
-
-[options.packages.find]
-where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ include_pacakge_data = True
 python_requires = >=3.6
 install_requires =
     packaging
-    serviceinstaller >= 0.1.3; sys_platform == 'linux'
+    serviceinstaller >= 0.2.0; sys_platform == 'linux'
     simpleeval
     tomli>=1.1
     tomli_w>=0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,22 +23,25 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Atmospheric Science
     Topic :: Scientific/Engineering :: Physics
     Topic :: System :: Monitoring
     Topic :: System :: Networking :: Monitoring :: Hardware Watchdog
 keywords = iot lightning sensor remote control research m2m raspberry pi rpi
 project_urls =
-    Github = https://github.com/project-mjolnir/brokkr
-    Bug Tracker = https://github.com/project-mjolnir/brokkr/issues
-    Demo = https://hamma.dev/
+    Live Demo = https://hamma.dev/
+    Repository = https://github.com/project-mjolnir/brokkr
+    Documentation = https://github.com/project-mjolnir/brokkr#readme
+    Changelog = https://github.com/project-mjolnir/brokkr/blob/master/CHANGELOG.md
+    Issue Tracker = https://github.com/project-mjolnir/brokkr/issues
 
 [options]
 packages = find:
 install_requires =
-    packaging
+    packaging>=17
     serviceinstaller>=0.2.0;sys_platform == 'linux'
-    simpleeval
+    simpleeval>=0.9.11
     tomli>=1.1
     tomli-w>=0.4
 python_requires = >=3.6

--- a/src/brokkr/__init__.py
+++ b/src/brokkr/__init__.py
@@ -2,5 +2,4 @@
 Brokkr, a scientific IoT sensor client for data logging, uplink and control.
 """
 
-VERSION_INFO = (0, 4, 0, "dev2")
-__version__ = ".".join((str(version) for version in VERSION_INFO))
+__version__ = "0.4.0.dev2"

--- a/src/brokkr/__init__.py
+++ b/src/brokkr/__init__.py
@@ -2,4 +2,4 @@
 Brokkr, a scientific IoT sensor client for data logging, uplink and control.
 """
 
-__version__ = "0.4.0.dev2"
+__version__ = "0.4.0"

--- a/src/brokkr/config/base.py
+++ b/src/brokkr/config/base.py
@@ -13,8 +13,8 @@ import os
 from pathlib import Path
 
 # Third party imports
-import toml
-import toml.decoder
+import tomli
+import tomli_w
 
 # Local imports
 from brokkr.constants import (
@@ -81,8 +81,9 @@ def read_config_file(path, extension=None, logger=None):
     check_extension_supported(extension)
     if extension == EXTENSION_TOML:
         try:
-            config_data = toml.load(path)
-        except toml.decoder.TomlDecodeError as e:
+            with open(path, mode="rb") as toml_file:
+                config_data = tomli.load(toml_file)
+        except tomli.TOMLDecodeError as e:
             if logger is not None:
                 logger.error("%s reading TOML config file %r: %s",
                              type(e).__name__, path.as_posix(), e)
@@ -110,10 +111,11 @@ def write_config_file(config_data, path, extension=None):
         extension = Path(path).suffix.strip(".")
     check_extension_supported(extension)
     os.makedirs(path.parent, exist_ok=True)
-    with open(path, mode="w", encoding="utf-8", newline="\n") as config_file:
-        if extension == EXTENSION_TOML:
-            toml.dump(config_data, config_file)
-        elif extension == EXTENSION_JSON:
+    if extension == EXTENSION_TOML:
+        with open(path, "wb") as config_file:
+            tomli_w.dump(config_data, config_file)
+    elif extension == EXTENSION_JSON:
+        with open(path, "w", encoding="utf-8", newline="\n") as config_file:
             json.dump(config_data, config_file,
                       allow_nan=False, separators=JSON_SEPERATORS)
 

--- a/src/brokkr/config/base.py
+++ b/src/brokkr/config/base.py
@@ -503,11 +503,13 @@ class ConfigHandlerFactory(brokkr.utils.misc.AutoReprMixin):
             self,
             level_presets=None,
             overlays=None,
+            ignore_cli_args=False,
             **default_type_kwargs,
                 ):
-        self.level_presets = (CONFIG_LEVEL_PRESETS if level_presets is None
-                              else level_presets)
+        self.level_presets = (
+            CONFIG_LEVEL_PRESETS if level_presets is None else level_presets)
         self.overlays = overlays
+        self.ignore_cli_args = ignore_cli_args
         self.default_type_kwargs = default_type_kwargs
 
     def create_config_handler(self, name, config_levels, **type_kwargs):
@@ -534,6 +536,9 @@ class ConfigHandlerFactory(brokkr.utils.misc.AutoReprMixin):
                     level_args["name"] = level_args.get("name", config_level)
                 config_level = level_class(
                     config_type=config_type, **level_args)
+            if (self.ignore_cli_args
+                    and isinstance(config_level, CLIArgsConfigLevel)):
+                continue
             rendered_config_levels.append(config_level)
 
         config_handler = ConfigHandler(config_type=config_type,

--- a/src/brokkr/config/confighandlers.py
+++ b/src/brokkr/config/confighandlers.py
@@ -41,6 +41,7 @@ CONFIG_HANDLER_FACTORY = brokkr.config.base.ConfigHandlerFactory(
     local_config_path=CONFIG_PATH_LOCAL / METADATA["name"],
     preset_config_path=SYSTEM_BASE_PATH / SYSTEM_SUBPATH_CONFIG,
     config_version=CONFIG_VERSION,
+    ignore_cli_args=(not brokkr.utils.misc.get_cli_invoked()),
     )
 
 DEFAULT_CONFIG_UNIT = {

--- a/src/brokkr/config/metadatahandler.py
+++ b/src/brokkr/config/metadatahandler.py
@@ -19,6 +19,7 @@ SYSTEM_PATH = brokkr.utils.misc.get_system_path(SYSTEMPATH_CONFIG)
 CONFIG_HANDLER_FACTORY = brokkr.config.base.ConfigHandlerFactory(
     preset_config_path=SYSTEM_PATH,
     config_version=CONFIG_VERSION,
+    ignore_cli_args=(not brokkr.utils.misc.get_cli_invoked()),
     )
 
 

--- a/src/brokkr/config/modehandler.py
+++ b/src/brokkr/config/modehandler.py
@@ -27,6 +27,7 @@ CONFIG_HANDLER_FACTORY = brokkr.config.base.ConfigHandlerFactory(
     preset_config_path=(brokkr.utils.misc.get_system_path(SYSTEMPATH_CONFIG)
                         / SYSTEM_SUBPATH_CONFIG),
     config_version=CONFIG_VERSION,
+    ignore_cli_args=(not brokkr.utils.misc.get_cli_invoked()),
     )
 
 

--- a/src/brokkr/config/systempathhandler.py
+++ b/src/brokkr/config/systempathhandler.py
@@ -12,11 +12,13 @@ from brokkr.constants import (
     PACKAGE_NAME,
     SYSTEM_NAME_DEFAULT,
     )
+import brokkr.utils.misc
 
 
 CONFIG_HANDLER_FACTORY = brokkr.config.base.ConfigHandlerFactory(
     local_config_path=CONFIG_PATH_LOCAL,
     config_version=CONFIG_VERSION,
+    ignore_cli_args=(not brokkr.utils.misc.get_cli_invoked()),
     )
 
 

--- a/src/brokkr/multiprocess/handler.py
+++ b/src/brokkr/multiprocess/handler.py
@@ -247,12 +247,11 @@ class MultiprocessHandler(brokkr.utils.misc.AutoReprMixin):
                 worker.terminate()
                 self.logger.info("Terminated worker %s", worker)
                 n_terminated += 1
-            else:
-                if worker.exitcode:
-                    self.logger.error("Worker %s failed with exitcode %s",
-                                      worker, worker.exitcode)
-                    self.logger.info("Process info %r", worker)
-                    n_failed += 1
+            elif worker.exitcode:
+                self.logger.error("Worker %s failed with exitcode %s",
+                                  worker, worker.exitcode)
+                self.logger.info("Process info %r", worker)
+                n_failed += 1
             self.logger.debug("Worker %s shut down successfully", worker)
             try:
                 worker.close()

--- a/src/brokkr/multiprocess/handler.py
+++ b/src/brokkr/multiprocess/handler.py
@@ -27,6 +27,7 @@ def start_worker_process(
         log_configurator=None,
         configurator_kwargs=None,
         exit_event=None,
+        on_startup=None,
         ):
     if log_configurator is not None:
         if configurator_kwargs is None:
@@ -35,6 +36,11 @@ def start_worker_process(
 
     logger = logging.getLogger(__name__)
     logger.info("Started worker process %s", worker_config.name)
+
+    if on_startup is not None:
+        logger.debug("Running on-startup callback %r", on_startup)
+        on_startup()
+
     executor = worker_config.executor
     if worker_config.build_method:
         try:
@@ -111,6 +117,7 @@ class MultiprocessHandler(brokkr.utils.misc.AutoReprMixin):
             logging_shutdown_wait_s=LOGGING_SHUTDOWN_WAIT_S,
             exit_event=None,
             before_startup=None,
+            on_startup=None,
             after_shutdown=None,
                 ):
         if worker_configs is None:
@@ -132,6 +139,7 @@ class MultiprocessHandler(brokkr.utils.misc.AutoReprMixin):
         self.exit_event = exit_event
 
         self.before_startup = before_startup
+        self.on_startup = on_startup
         self.after_shutdown = after_shutdown
 
     def start_logger(self, ignore_started=False):
@@ -198,6 +206,7 @@ class MultiprocessHandler(brokkr.utils.misc.AutoReprMixin):
                         "filter_level": self.log_filter_level,
                         },
                     "exit_event": self.exit_event,
+                    "on_startup": self.on_startup,
                     },
                 )
             self.workers.append(worker)

--- a/src/brokkr/pipeline/utils.py
+++ b/src/brokkr/pipeline/utils.py
@@ -52,17 +52,16 @@ def get_data_object(input_data, key_name=None, pop_input=False):
                 raise KeyError(error_message) from None
             if pop_input:
                 input_data.remove(output_data_object)
+    elif len(input_data) == 1:
+        try:
+            input_data = list(input_data.values())
+        except AttributeError:  # Input data isn't a dict
+            pass
+        output_data_object = input_data[0]
+        if pop_input:
+            input_data.clear()
     else:
-        if len(input_data) == 1:
-            try:
-                input_data = list(input_data.values())
-            except AttributeError:  # Input data isn't a dict
-                pass
-            output_data_object = input_data[0]
-            if pop_input:
-                input_data.clear()
-        else:
-            output_data_object = input_data
+        output_data_object = input_data
     return output_data_object
 
 

--- a/src/brokkr/utils/cli.py
+++ b/src/brokkr/utils/cli.py
@@ -334,6 +334,8 @@ def dispatch_command(subcommand, parsed_args):
 
 
 def main():
+    import brokkr.utils.misc  # pylint: disable=import-outside-toplevel
+    brokkr.utils.misc.set_cli_invoked(True)
     subcommand, parsed_args = parse_args()
     dispatch_command(subcommand, vars(parsed_args))
 

--- a/src/brokkr/utils/cli.py
+++ b/src/brokkr/utils/cli.py
@@ -265,11 +265,19 @@ def generate_argparser_main():
 
     for service_parser in service_parsers:
         service_parser.add_argument(
-            "--user-account",
-            help="User to run the installed service as, if not the current")
+            "--account",
+            help="User account to run the service under, if not the current")
         service_parser.add_argument(
-            "--platform", choices={"linux", },
+            "--output-path",
+            help="Path to write the service file, if not the platform default")
+        service_parser.add_argument(
+            "--skip-enable", action="store_true",
+            help="Skip enabling/disabling services, just write service file")
+        service_parser.add_argument(
+            "--platform", choices=("linux", ),
             help="Manually override automatic platform detection")
+        service_parser.add_argument(
+            "--extra-args", help="Extra args to pass when starting service")
 
     return parser_main
 

--- a/src/brokkr/utils/log.py
+++ b/src/brokkr/utils/log.py
@@ -89,7 +89,7 @@ def setup_log_levels(log_config, file_level=None, console_level=None):
                 log_config["root"]["handlers"].append(handler)
     levels_tocheck = (level for level in (
         file_level, console_level, log_config["root"]["level"]
-        ) if (level == 0 or level))
+        ) if (level == 0 or level))  # pylint: disable=compare-to-zero
     level_min = min((int(getattr(logging, str(level_name), level_name))
                      for level_name in levels_tocheck))
     log_config["root"]["level"] = level_min

--- a/src/brokkr/utils/misc.py
+++ b/src/brokkr/utils/misc.py
@@ -29,7 +29,7 @@ from brokkr.constants import (
 
 # Constants for run periodic
 NS_IN_S = int(1e9)
-SIGNALS_SET = ["SIG" + signame for signame in {"TERM", "HUP", "INT", "BREAK"}]
+SIGNALS_SET = ["SIG" + signame for signame in ["TERM", "HUP", "INT", "BREAK"]]
 
 
 # --- Time functions --- #

--- a/src/brokkr/utils/misc.py
+++ b/src/brokkr/utils/misc.py
@@ -21,15 +21,16 @@ import packaging.version
 # Local imports
 import brokkr
 from brokkr.constants import (
-    SLEEP_TICK_S,
     LEVEL_NAME_SYSTEM,
+    SLEEP_TICK_S,
     SYSTEM_NAME_DEFAULT,
     )
 
 
-# Constants for run periodic
 NS_IN_S = int(1e9)
 SIGNALS_SET = ["SIG" + signame for signame in ["TERM", "HUP", "INT", "BREAK"]]
+
+CLI_INVOKED_ENV_VAR = "BROKKR_CLI_INVOKED"
 
 
 # --- Time functions --- #
@@ -147,6 +148,14 @@ def convert_path(path):
     path = Path(
         str(path).replace("~", "~" + os.getenv("SUDO_USER", ""))).expanduser()
     return path
+
+
+def get_cli_invoked():
+    return bool(os.environ.get(CLI_INVOKED_ENV_VAR, False))
+
+
+def set_cli_invoked(value=True):
+    os.environ[CLI_INVOKED_ENV_VAR] = str(value) if value else ""
 
 
 # --- System path utilities --- #

--- a/src/brokkr/utils/network.py
+++ b/src/brokkr/utils/network.py
@@ -111,7 +111,7 @@ def setup_socket(  # pylint: disable=dangerous-default-value
             getattr(sock, action)(address_tuple)
     except Exception as e:
         if isinstance(e, OSError):
-            # pylint: disable=no-member
+            # pylint: disable=no-member, useless-suppression
             if error_codes_suppress and (
                     isinstance(e, socket.timeout)
                     or (e.errno

--- a/src/brokkr/utils/network.py
+++ b/src/brokkr/utils/network.py
@@ -145,7 +145,7 @@ def recieve_all(
                 <= (timeout_s * brokkr.utils.misc.NS_IN_S))):
         try:
             chunk = sock.recv(buffer_size)
-            if len(chunks) == 0:
+            if not chunks:
                 LOGGER.debug(
                     "First chunk of network data recieved of length %s bytes",
                     len(chunk))

--- a/src/brokkr/utils/output.py
+++ b/src/brokkr/utils/output.py
@@ -267,17 +267,22 @@ def render_output_filename(
         all_filename_kwargs["drive_path"] = str(drive_path)
 
     # Add master output path to output path if is relative
-    output_path = Path(output_path.format(**all_filename_kwargs))
+    output_path = Path(str(output_path).format(**all_filename_kwargs))
+    LOGGER.debug("Intermediate output path: %s", output_path.as_posix())
     if not output_path.is_absolute():
         output_path_root = Path(
             CONFIG["general"]["output_path_client"].as_posix().format(
                 system_name=METADATA["name"]))
         if output_path_root:
             output_path = output_path_root / output_path
+            LOGGER.debug(
+                "Added root %r to relative output path",
+                output_path_root.as_posix())
     output_path = brokkr.utils.misc.convert_path(output_path)
 
     rendered_filename = filename_template.format(**all_filename_kwargs)
-    output_path = (Path(output_path) / rendered_filename)
+    LOGGER.debug("Rendered filename: %r", rendered_filename)
+    output_path = output_path / rendered_filename
 
     # Add file extension if it has not yet been affixed and is passed
     if extension is not None and not output_path.suffix:

--- a/src/brokkr/utils/output.py
+++ b/src/brokkr/utils/output.py
@@ -55,6 +55,7 @@ def format_data(
         # Build list of values to print per data object
         data_componets = [f"{name}:", f"{value}"]
         if not getattr(data_value, "is_na", data_value == "NA"):
+            # Add details for data that is not NA
             if unit:
                 data_componets.append(f"{unit}")
             if (uncertainty not in (None, False)
@@ -65,7 +66,9 @@ def format_data(
                     data_componets.append(f"{unit}")
             if raw_value is not None and include_raw:
                 data_componets.append(f"(Raw: {raw_value!r})")
+        # pylint: disable-next=confusing-consecutive-elif
         elif getattr(data_value, "value", data_value) != "NA":
+            # Mark data as NA if is_na set but doesn't have a value of NA
             data_componets.append("(NA)")
         data_item = " ".join(data_componets)
         output_data_list.append(data_item)

--- a/src/brokkr/utils/ports.py
+++ b/src/brokkr/utils/ports.py
@@ -62,9 +62,11 @@ def reset_usb_port(port_object):
                       "r", encoding="utf-8") as num_file:
                 num_raw = num_file.readline()
             usb_num_parts[usb_num_part] = num_raw.strip().zfill(3)
+        # pylint: disable-next=consider-using-f-string
         usb_device_path = "/dev/bus/usb/{busnum}/{devnum}".format(
             **usb_num_parts)
         LOGGER.debug("Resetting USB device at %r", usb_device_path)
+        # pylint: disable-next=unspecified-encoding
         with open(usb_device_path, "w", os.O_WRONLY) as device_file:
             fcntl.ioctl(device_file, USBDEVFS_RESET, 0)
     # Ignore error loading fcntl if on Windows as it isn't present

--- a/src/brokkr/utils/services.py
+++ b/src/brokkr/utils/services.py
@@ -16,9 +16,8 @@ from brokkr.constants import PACKAGE_NAME
 AUTOSSH_REMOTE_PORT = (
     CONFIG["autossh"]["tunnel_port_offset"] + UNIT_CONFIG["number"])
 
-AUTOSSH_SERVICE_NAME = "autossh-{}.service".format(METADATA["name"])
-BROKKR_SERVICE_NAME = "{package_name}-{system_name}.service".format(
-    package_name=PACKAGE_NAME, system_name=METADATA["name"])
+AUTOSSH_SERVICE_NAME = f'autossh-{METADATA["name"]}.service'
+BROKKR_SERVICE_NAME = f'{PACKAGE_NAME}-{METADATA["name"]}.service'
 
 # Get system fullname
 if METADATA["name_full"]:


### PR DESCRIPTION
See Changelog for full details of changes.

* Don't read the CLI argv into a config level if not actually running from Brokkr's own CLI (e.g. Sindri)
* Migrate from unmaintained `toml` to `tomli` for better maintenance, performance, robustness and TOML 1.0.0 support
* Further update packaging infra and metadata
* Update/better constrain dep versions
* Heavily update Readme, Contributing Guide and Release procedure
* Release Brokkr 0.4.0, since its essentially stable now

Close #3 